### PR TITLE
Analysis: Create PoI divergence analysis notebook templates

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -1,0 +1,45 @@
+# Dispute analysis tools
+
+Tools for analyzing data divergences on the network.
+
+## Prerequisites
+
+The tools here use Python libraries that must be installed before usage. These may be installed individually using
+`pip`, but the recommended method is to install the `Conda` package which includes all the tools you'll need.
+
+## Tools 
+
+### Jupyter Notebooks
+The Jupyter Notebook is an open-source web application that allows you to create and share documents that contain live code, equations, visualizations and narrative text.
+
+#### Dependencies
+The notebooks make use of several dependencies not included in the base conda environment.
+```
+conda install -c conda-forge jupyter_contrib_nbextensions jupyter_nbextensions_configurator web3
+pip install itables
+```   
+
+There are some recommended but optional Jupyter extensions. To install:
+    ```
+    jupyter contrib nbextension install --user
+    jupyter nbextension enable hide_input/main
+    jupyter nbextension enable hide_input_all/main 
+    jupyter nbextension enable execute_time/ExecuteTime 
+    jupyter nbextension enable collapsible_headings/main 
+    jupyter nbextension enable splitcell/splitcell 
+    jupyter nbextension enable toc2/main
+    ```
+
+### Setup
+
+To spin up a Jupyter notebook server:
+1. Navigate to the root analysis directory in you terminal.
+2. Spin up a Jupyter server (it should automatically open in your browser)
+   
+    From the terminal in this directory run:
+    ```    
+    jupyter notebook
+    ```
+3. Explore one of the existing notebooks, duplicate and modify, or create your own! See the [documentation](https://jupyter.readthedocs.io/en/latest/) for help getting started. The `Template` notebooks are designed as a starting point for new analyse. Duplicate into a new one and have at it!
+
+_note: If you create a useful/interesting notebook don't forget to commit it to this repo and push it for others to use as well!_

--- a/analysis/notebooks/PoI comparison - TEMPLATE.ipynb
+++ b/analysis/notebooks/PoI comparison - TEMPLATE.ipynb
@@ -1,0 +1,806 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-09T22:17:21.309761Z",
+     "start_time": "2021-06-09T22:17:21.264714Z"
+    }
+   },
+   "source": [
+    "Investigating the <SUBGRAPH_NAME> subgraph deployment with reported PoI inconsistencies - \n",
+    "- explorer: `https://thegraph.com/explorer/subgraph/<...>'\n",
+    "- IPFS hash: `<DEPLOYMENT_ID>`\n",
+    "- subgraph id: `<SUBGRAPH_ID>`\n",
+    "- displayName: `<SUBGRAPH_NAME>`\n",
+    "- repo: `https://github.com/<...>`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-11T20:45:57.874080Z",
+     "start_time": "2021-06-11T20:45:57.820514Z"
+    }
+   },
+   "source": [
+    "# Instructions\n",
+    "\n",
+    "- Extract relevant PoI tables from indexer infrastructures \n",
+    "    ``` \n",
+    "    # connect to database and run following command to find out which schema the deployment is in\n",
+    "    select name from public.deployment_schemas where subgraph = '<DEPLOYMENT_ID>';\n",
+    "\n",
+    "    # exit psql cli then dump the PoI table (you may need to change --host and --port)\n",
+    "    pg_dump --dbname=\"graph\" --host=localhost --port=5432 --username=<YOUR_USERNAME>  --table='<SCHEMA_NAME_RESULT_FROM_ABOVE>.\"poi2$\"' --file=<FILE_LOCATION_OF_CHOICE>.sql'\n",
+    "    ```\n",
+    "\n",
+    "- Place PoI table dumps (.sql) in local directory (recommend using the data directory in this repo)\n",
+    "- Update configs values (section 2.1 below)\n",
+    "- Run all cells (Use topnav: `Cell`>`Run all`)\n",
+    "- Entity updates in the divergent blocks will be saved to a .csv in the output directory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Imports and Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:39.727966Z",
+     "start_time": "2021-06-14T21:36:39.725122Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Investigation config\n",
+    "subgraph_name = '<SUBGRAPH_NAME>'\n",
+    "subgraph_id = '<DEPLOYMENT_ID>' # 'Qm...'\n",
+    "poi_directory = \"../data/\"\n",
+    "output_dir = '../outputs/'\n",
+    "\n",
+    "# DB connection config\n",
+    "POSTGRES_HOST = 'localhost'\n",
+    "POSTGRES_PORT = '5432'\n",
+    "POSTGRES_USERNAME = '<USERNAME>' \n",
+    "POSTGRES_PASSWORD = '<PASSWORD>' \n",
+    "POSTGRES_DBNAME = 'poi_analysis' # should already exist on the DB server (you may need to `create database ..`)\n",
+    "\n",
+    "ETHEREUM_PROVIDER = '<ETHEREUM_CLIENT_ENDPOINT>'\n",
+    "IPFS_GATEWAY_MULTI_ADDRESS = '/dns/ipfs.infura.io/tcp/5001/https'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import required libs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:40.338000Z",
+     "start_time": "2021-06-14T21:36:39.729787Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>.container { width:100% !important; }</style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Setup auto reload, so any changes to underlying libs are applied\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "%matplotlib inline\n",
+    "from IPython.core.display import display, HTML\n",
+    "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.440445Z",
+     "start_time": "2021-06-14T21:36:40.339865Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Import libs\n",
+    "import os\n",
+    "import sys \n",
+    "import re \n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import json\n",
+    "from functools import reduce\n",
+    "from  matplotlib import pyplot\n",
+    "import plotly\n",
+    "import seaborn\n",
+    "import plotly.express as px\n",
+    "seaborn.set()\n",
+    "seaborn.set(font_scale=1.5)\n",
+    "from sqlalchemy import create_engine\n",
+    "import itertools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connect to DB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.524119Z",
+     "start_time": "2021-06-14T21:36:41.442527Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Create connection to local compare DB\n",
+    "postgres_str = ('postgresql://{username}:{password}@{ipaddress}:{port}/{dbname}'\n",
+    ".format(username=POSTGRES_USERNAME,\n",
+    "password=POSTGRES_PASSWORD,\n",
+    "ipaddress=POSTGRES_HOST,\n",
+    "port=POSTGRES_PORT,\n",
+    "dbname=POSTGRES_DBNAME))\n",
+    "\n",
+    "local_compare_db_cnx = create_engine(postgres_str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Transform and Load Reference PoI Tables into DB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.555552Z",
+     "start_time": "2021-06-14T21:36:41.525695Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#defining the replace method\n",
+    "def replace_table_name(file_path, subs, flags=0):\n",
+    "    with open(file_path, \"r+\") as file:\n",
+    "        #read the file contents\n",
+    "        file_contents = file.read()\n",
+    "        file_contents = re.sub('\"sgd\\d{1,3}\".\"poi2\\$\"', subs, file_contents, flags = re.M)\n",
+    "        file_contents = re.sub('sgd\\d{1,3}.\"poi2\\$\"', subs, file_contents, flags = re.M)\n",
+    "        file_contents = re.sub('sgd\\d{1,3}.\"poi2\\$', subs, file_contents, flags = re.M)\n",
+    "        file.seek(0)\n",
+    "        file.truncate()\n",
+    "        file.write(file_contents)        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.871169Z",
+     "start_time": "2021-06-14T21:36:41.556862Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "## Ensure schema exists\n",
+    "schemas_query = \"\"\"SELECT s.nspname AS schema_table FROM pg_catalog.pg_namespace s where nspname = '{namespace_name}'\"\"\".format(namespace_name=subgraph_name)\n",
+    "schemas = pd.read_sql_query(schemas_query, con=local_compare_db_cnx)\n",
+    "if len(schemas) == 0:\n",
+    "    create_schema_query = \"\"\"CREATE SCHEMA {namespace_name};\"\"\".format(namespace_name=subgraph_name)\n",
+    "    pd.read_sql_query(create_schema_query, con=local_compare_db_cnx)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.874329Z",
+     "start_time": "2021-06-14T21:36:39.735Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Update schema and table names for all files in directory\n",
+    "# insert into db\n",
+    "for filename in os.listdir(poi_directory):\n",
+    "    if (filename.split('.')[-1] != 'sql'):\n",
+    "        continue\n",
+    "    indexer = filename.split('_')[0]\n",
+    "    table_name = subgraph_name + '.' + indexer\n",
+    "    full_filename = os.path.join(poi_directory, filename)\n",
+    "    print('Loading', table_name)\n",
+    "    replace_table_name(full_filename, table_name)    \n",
+    "    tables_query = \"\"\" select tablename from pg_catalog.pg_tables where schemaname='{namespace_name}' and tablename='{name}';\"\"\".format(name=indexer, namespace_name=subgraph_name)\n",
+    "    matching_tables = pd.read_sql_query(tables_query, con=local_compare_db_cnx)\n",
+    "    if len(matching_tables) == 1:\n",
+    "        print(table_name, 'already in DB')\n",
+    "    if len(matching_tables) == 0:\n",
+    "        table_load_command = \"\"\"psql -d disputed_indexers -f {sql_table_file}\"\"\".format(sql_table_file=full_filename)\n",
+    "        print('Inserting', table_name)\n",
+    "        print(table_load_command)\n",
+    "        res = os.system(table_load_command)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.875394Z",
+     "start_time": "2021-06-14T21:36:39.737Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Get list of all PoI tables in the compare db?\n",
+    "tables_query = \"\"\" select tablename from pg_catalog.pg_tables where schemaname='{namespace_name}';\"\"\".format(namespace_name=subgraph_name)\n",
+    "ref_tables = pd.read_sql_query(tables_query, con=local_compare_db_cnx)\n",
+    "ref_tables"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compare reference datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.876867Z",
+     "start_time": "2021-06-14T21:36:39.739Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "reference_poi_dfs = []\n",
+    "for table in ref_tables.iterrows():\n",
+    "    name = table[1][0]   \n",
+    "    digest_name = name\n",
+    "    table_query = \"\"\"select * from {namespace_name}.{table_name}\"\"\".format(namespace_name=subgraph_name, table_name=name)\n",
+    "    table_df = pd.read_sql_query(table_query, con=local_compare_db_cnx).rename(columns={'digest': digest_name})\n",
+    "    table_df['block_source'] = table_df['block_range'].apply(lambda x: x.lower)\n",
+    "    reference_poi_dfs.append(table_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.877914Z",
+     "start_time": "2021-06-14T21:36:39.741Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "poi_compare = reduce(lambda left,right: pd.merge(left,right,on='block_source', suffixes=('_left', '_right')), reference_poi_dfs)\n",
+    "poi_compare = poi_compare.loc[:,~poi_compare.columns.duplicated()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.878945Z",
+     "start_time": "2021-06-14T21:36:39.742Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# COMPARE ALL REFERENCE DIGESTS\n",
+    "poi_compare = poi_compare.drop(['vid', 'vid_left', 'vid_right', 'id', 'id_left', 'id_right', 'block_range_left', 'block_range_right'], axis=1, errors='ignore')\n",
+    "digest_columns = filter(lambda c: (c.__contains__('block') == False), poi_compare.columns)\n",
+    "poi_compare['block_source'] = poi_compare['block_source']\n",
+    "\n",
+    "for pair in itertools.combinations(digest_columns, 2):\n",
+    "    column_name = pair[0] + '_' + pair[1]\n",
+    "    poi_compare[column_name] = poi_compare[pair[0]] == poi_compare[pair[1]]    \n",
+    "    poi_compare[column_name + '_numeric'] = poi_compare[column_name].apply(lambda x: 1 if x else -1)\n",
+    "\n",
+    "numeric_df_columns = list(filter(lambda c: c.__contains__('numeric'), poi_compare.columns))\n",
+    "numeric_df_columns.append('block_source')\n",
+    "poi_compare_numeric = poi_compare[numeric_df_columns]\n",
+    "poi_compare_numeric.columns = poi_compare_numeric.columns.str.replace('_numeric', '')\n",
+    "# poi_compare    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.879954Z",
+     "start_time": "2021-06-14T21:36:39.745Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# CREATE MELTED VERSION FOR CHARTING\n",
+    "melted_numeric = poi_compare_numeric.melt(id_vars='block_source')\n",
+    "# melted_numeric"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Analyze PoI Differences"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get divergent block numbers\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.880834Z",
+     "start_time": "2021-06-14T21:36:39.748Z"
+    },
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "# Identify divergent block_source in each numeric compare column (return object with block numbers?)\n",
+    "compare_columns = list(filter(lambda c: (c.__contains__('block') == False), poi_compare_numeric.columns))\n",
+    "divergent_blocks = pd.DataFrame(columns=['comparison', 'divergent_block'])\n",
+    "\n",
+    "for column in compare_columns:\n",
+    "    index = (poi_compare_numeric[column].values == -1).argmax()\n",
+    "    divergent_blocks = divergent_blocks.append(\n",
+    "        {\n",
+    "            'comparison': column, \n",
+    "            'subgraph': subgraph_id,\n",
+    "            'divergent_block': poi_compare.iloc[index]['block_source'],\n",
+    "        }, \n",
+    "        ignore_index=True\n",
+    "    )\n",
+    "divergent_blocks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.881702Z",
+     "start_time": "2021-06-14T21:36:39.749Z"
+    },
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "unique_divergent_blocks = divergent_blocks.divergent_block.unique()\n",
+    "print('Unique divergent blocks')\n",
+    "print(unique_divergent_blocks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.882683Z",
+     "start_time": "2021-06-14T21:36:39.751Z"
+    },
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "# CHART\n",
+    "melted_numeric = melted_numeric.sort_values(by=['block_source'], ascending=True)\n",
+    "fig = px.area(melted_numeric, x='block_source', y='value', color='variable', title='Where do the PoIs diverge?')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.883584Z",
+     "start_time": "2021-06-14T21:36:39.753Z"
+    },
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "# ZOOMED CHART\n",
+    "lower_bound = min(unique_divergent_blocks) - 500\n",
+    "upper_bound = max(unique_divergent_blocks) + 500\n",
+    "melted_numeric_zoomed = melted_numeric[(melted_numeric['block_source'] > lower_bound) & (melted_numeric['block_source'] < upper_bound)]\n",
+    "fig = px.area(melted_numeric_zoomed, x='block_source', y='value', color='variable', title='Zoomed in on the divergence')\n",
+    "fig.update_layout(xaxis=dict(tickformat=\".\"))\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save analysis to csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.884511Z",
+     "start_time": "2021-06-14T21:36:39.755Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Save comparison table to a local csv\n",
+    "compare_table_location = output_dir + subgraph_name + '_compare_pois.csv'\n",
+    "poi_compare_numeric.to_csv(compare_table_location, index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.885785Z",
+     "start_time": "2021-06-14T21:36:39.756Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Save divergent blocks table to a local csv\n",
+    "divergence_table_location = output_dir + subgraph_name + '_poi_divergence_blocks.csv'\n",
+    "divergent_blocks.to_csv(divergence_table_location, index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Analyze divergent blocks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.886669Z",
+     "start_time": "2021-06-14T21:36:39.758Z"
+    },
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "pip install web3\n",
+    "pip install pyyaml\n",
+    "pip install ipfshttpclient==0.7.0a1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.887567Z",
+     "start_time": "2021-06-14T21:36:39.759Z"
+    },
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "from web3 import Web3\n",
+    "import yaml\n",
+    "import ipfshttpclient"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.888598Z",
+     "start_time": "2021-06-14T21:36:39.761Z"
+    },
+    "hide_input": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "w3 = Web3(Web3.HTTPProvider(ETHEREUM_PROVIDER))\n",
+    "ipfs = ipfshttpclient.connect(IPFS_GATEWAY_MULTI_ADDRESS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.889553Z",
+     "start_time": "2021-06-14T21:36:39.762Z"
+    },
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "class DataSource:\n",
+    "    def __init__(self, address, abi_name, abi, events):\n",
+    "        self.abi_name = abi_name\n",
+    "        self.abi = abi\n",
+    "        self.address = address\n",
+    "        self.events = events\n",
+    "\n",
+    "def getSource(data_source):\n",
+    "    address = data_source['source']['address']\n",
+    "    abi_name = data_source['source']['abi']    \n",
+    "    abi_location = list(filter(lambda abi: abi['name'] == abi_name, data_source['mapping']['abis']))[0]['file']['/']\n",
+    "    abi = ipfs.cat(abi_location)\n",
+    "    events = data_source['mapping']['eventHandlers']      \n",
+    "    return DataSource(address, abi_name, abi, events)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.890554Z",
+     "start_time": "2021-06-14T21:36:39.764Z"
+    },
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_matching_events(datasources, divergent_blocks):\n",
+    "    matching_events = pd.DataFrame(columns=['address', 'block', 'event', 'subgraph_events', 'handlers', 'log_params'])\n",
+    "    for source in datasources:\n",
+    "        address = w3.toChecksumAddress(source.address)\n",
+    "        print('source address', address)\n",
+    "        contract_abi = source.abi.decode(\"utf-8\")\n",
+    "        contract = w3.eth.contract(address=address, abi=contract_abi)\n",
+    "        for block in divergent_blocks:\n",
+    "            print('  block:', block)\n",
+    "            logs_filter_params = {'fromBlock': block, 'toBlock': block, 'address': address}\n",
+    "            logs_filter = w3.eth.filter(logs_filter_params)\n",
+    "            logs = w3.eth.get_filter_logs(logs_filter.filter_id)\n",
+    "            for log in logs:\n",
+    "                for contract_event in contract.events:\n",
+    "                    subgraph_events = list(filter(lambda e: e['event'].split('(')[0] == contract_event.event_name, source.events))\n",
+    "                    handlers = [subgraph_event['handler'] for subgraph_event in subgraph_events]\n",
+    "                    if len(subgraph_events) > 0:\n",
+    "                        tx_receipt = w3.eth.get_transaction_receipt(log.transactionHash)\n",
+    "                        decoded_logs = contract_event().processReceipt(tx_receipt)\n",
+    "                        for decoded_log in decoded_logs:\n",
+    "                            print('    - event:', contract_event.event_name)\n",
+    "                            print('      log_params:')\n",
+    "                            for arg, value in decoded_log.args.items():\n",
+    "                                print('          {arg}: {value}'.format(arg=arg, value=value))                            \n",
+    "                            matching_events = matching_events.append(\n",
+    "                                {\n",
+    "                                    'address': address, \n",
+    "                                    'block': block, \n",
+    "                                    'event': contract_event.event_name, \n",
+    "                                    'subgraph_events': subgraph_events,\n",
+    "                                    'handlers': handlers,\n",
+    "                                    'log_params': dict(decoded_log.args)\n",
+    "                                }, ignore_index=True)\n",
+    "    return matching_events"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.891419Z",
+     "start_time": "2021-06-14T21:36:39.766Z"
+    },
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "manifest = yaml.safe_load(ipfs.cat(subgraph_id))\n",
+    "data_sources = list(map(getSource, manifest[\"dataSources\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.892426Z",
+     "start_time": "2021-06-14T21:36:39.767Z"
+    },
+    "hide_input": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "matching_events = get_matching_events(data_sources, unique_divergent_blocks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.893360Z",
+     "start_time": "2021-06-14T21:36:39.769Z"
+    },
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "print('Matching events')\n",
+    "print(len(matching_events))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.894246Z",
+     "start_time": "2021-06-14T21:36:39.770Z"
+    },
+    "hide_input": true
+   },
+   "outputs": [],
+   "source": [
+    "# get list of unique events per contract & block\n",
+    "unique_event_signatures = matching_events.drop_duplicates(subset=['block', 'address', 'event']).drop(['log_params', 'subgraph_events'], axis=1)\n",
+    "print('Unique event signatures matched on divergent blocks')\n",
+    "unique_event_signatures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.895131Z",
+     "start_time": "2021-06-14T21:36:39.772Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print('Matching events emitted in divergent blocks (log params included)')\n",
+    "matching_events"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save analysis to csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.896073Z",
+     "start_time": "2021-06-14T21:36:39.773Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Save matching events to a local csv\n",
+    "matching_events.to_csv(output_dir + subgraph_name + '_matching_events_on_divergent_blocks.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T21:36:41.897023Z",
+     "start_time": "2021-06-14T21:36:39.775Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Save unique matching event signatures to a local csv\n",
+    "unique_event_signatures.to_csv(output_dir + subgraph_name + '_matching_event_signatures_on_divergent_blocks.csv')"
+   ]
+  }
+ ],
+ "metadata": {
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/analysis/notebooks/Subgraph Updates in Specific Blocks - TEMPLATE.ipynb
+++ b/analysis/notebooks/Subgraph Updates in Specific Blocks - TEMPLATE.ipynb
@@ -1,0 +1,359 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "heading_collapsed": true
+   },
+   "source": [
+    "# Instructions\n",
+    "\n",
+    "- Update configs values (section 2 below)\n",
+    "- Run all cells (Use topnav: `Cell`>`Run all`)\n",
+    "- Entity updates in the divergent blocks will be saved to a .csv in the output directory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2021-06-11T20:36:22.099Z"
+    }
+   },
+   "source": [
+    "# Configs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T22:05:22.628741Z",
+     "start_time": "2021-06-14T22:05:22.623957Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Investigation config\n",
+    "indexer_name = '<MY_INDEXER_NAME>'\n",
+    "subgraph_name = '<SUBGRAPH_NAME>'\n",
+    "subgraph_id = '<DEPLOYMENT_ID>'\n",
+    "chain_name = 'mainnet'\n",
+    "divergent_blocks = [<BLOCK_1>, <BLOCK_2>, ...]\n",
+    "output_dir = '../outputs/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T22:05:22.738102Z",
+     "start_time": "2021-06-14T22:05:22.735748Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Create connection to local indexer DB\n",
+    "POSTGRES_ADDRESS = 'localhost'\n",
+    "POSTGRES_PORT = '5432'\n",
+    "POSTGRES_USERNAME = '<USERNAME>' \n",
+    "POSTGRES_PASSWORD = '<PASSWORD>' \n",
+    "POSTGRES_DBNAME = '<DB>' "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2021-06-11T20:37:20.425Z"
+    },
+    "heading_collapsed": true
+   },
+   "source": [
+    "# Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T22:05:23.192766Z",
+     "start_time": "2021-06-14T22:05:22.739474Z"
+    },
+    "hidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>.container { width:100% !important; }</style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "%matplotlib inline\n",
+    "from IPython.core.display import display, HTML\n",
+    "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T22:05:23.545348Z",
+     "start_time": "2021-06-14T22:05:23.194221Z"
+    },
+    "hidden": true
+   },
+   "outputs": [],
+   "source": [
+    "# Import data processing and visualization libs\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sqlalchemy import create_engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T22:05:23.611069Z",
+     "start_time": "2021-06-14T22:05:23.546694Z"
+    },
+    "hidden": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create connection to local indexer DB\n",
+    "postgres_str = ('postgresql://{username}:{password}@{ipaddress}:{port}/{dbname}'.format(username=POSTGRES_USERNAME,\n",
+    "    password=POSTGRES_PASSWORD,\n",
+    "    ipaddress=POSTGRES_ADDRESS,\n",
+    "    port=POSTGRES_PORT,\n",
+    "    dbname=POSTGRES_DBNAME)\n",
+    ")\n",
+    "\n",
+    "indexer_local_db_cnx = create_engine(postgres_str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fetch entity updates"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup Fetch Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T22:05:23.642434Z",
+     "start_time": "2021-06-14T22:05:23.612671Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def fetch_entity_updates_in_block(indexer, db_cnx, divergent_block, deployment_id):\n",
+    "    schema = pd.read_sql(sql='SELECT name FROM public.deployment_schemas WHERE subgraph = \\'%s\\''%deployment_id, con=db_cnx)\n",
+    "    schema_name = schema.iat[0,0]\n",
+    "\n",
+    "    entity_tables_query = \"SELECT table_name FROM information_schema.tables WHERE table_schema = \\'%s\\'\"%schema_name\n",
+    "\n",
+    "    entity_tables = pd.read_sql(sql=entity_tables_query, con=db_cnx)\n",
+    "    entity_tables = entity_tables[entity_tables['table_name'] != 'poi2$']['table_name']\n",
+    "\n",
+    "    entity_names = []\n",
+    "    entity_changes = []\n",
+    "    divergent_blocks = []\n",
+    "    indexers = []\n",
+    "    subgraph_ids = []\n",
+    "    for table in entity_tables:\n",
+    "        changes_in_divergent_block = pd.read_sql(sql=\"SELECT * FROM %s.%s where lower(block_range)=%s\"%(schema_name, table, divergent_block), con=db_cnx)\n",
+    "        if len(changes_in_divergent_block) > 0:\n",
+    "            entity_names.append(table)\n",
+    "            entity_changes.append(changes_in_divergent_block.to_dict(orient='records'))\n",
+    "            divergent_blocks.append(divergent_block)\n",
+    "            indexers.append(indexer)\n",
+    "            subgraph_ids.append(subgraph_id)\n",
+    "    entity_changes_divergent_block = pd.DataFrame(list(zip(entity_names, entity_changes, divergent_blocks, indexers)),columns =['Entity', 'Updates', 'Block', 'Indexer'])\n",
+    "    return entity_changes_divergent_block\n",
+    "\n",
+    "def fetch_entity_updates_for_blocks(indexer, db_cnx, divergent_blocks, deployment_id):\n",
+    "    frames = []\n",
+    "    for block in divergent_blocks:\n",
+    "        changes = fetch_entity_updates_in_block(indexer, db_cnx, block, deployment_id)\n",
+    "        frames.append(changes)\n",
+    "    combined_df = pd.concat(frames, sort=False)\n",
+    "    return combined_df\n",
+    "\n",
+    "def fetch_eth_call_cached_results_for_blocks(indexer, db_cnx, divergent_blocks, chain, deployment_id):\n",
+    "    schema = pd.read_sql(sql='SELECT namespace FROM public.chains WHERE name = \\'%s\\''%chain, con=db_cnx)\n",
+    "    schema_name = schema.iat[0,0]\n",
+    "    \n",
+    "    call_cache_query = \"SELECT id, return_value, contract_address, block_number FROM {schema_name}.call_cache WHERE block_number in {blocks}\".format(schema_name=schema_name, blocks=divergent_blocks)\n",
+    "    call_cache_query = call_cache_query.replace('[', '(')\n",
+    "    call_cache_query = call_cache_query.replace(']', ')')\n",
+    "    \n",
+    "    call_cache_for_divergent_blocks = pd.read_sql(sql=call_cache_query, con=db_cnx)\n",
+    "    call_cache_for_divergent_blocks['indexer'] = indexer\n",
+    "    return call_cache_for_divergent_blocks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fetch entity updates from local indexer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T22:05:23.807607Z",
+     "start_time": "2021-06-14T22:05:23.643678Z"
+    }
+   },
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'indexer_name' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-7-05bcc5ac4aa6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mlocal_diverge_changes\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfetch_entity_updates_for_blocks\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mindexer_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mindexer_local_db_cnx\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdivergent_blocks\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msubgraph_id\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mlocal_diverge_call_cache\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfetch_eth_call_cached_results_for_blocks\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mindexer_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mindexer_local_db_cnx\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdivergent_blocks\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mchain_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msubgraph_id\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'indexer_name' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "local_diverge_changes = fetch_entity_updates_for_blocks(indexer_name, indexer_local_db_cnx, divergent_blocks, subgraph_id)\n",
+    "local_diverge_call_cache = fetch_eth_call_cached_results_for_blocks(indexer_name, indexer_local_db_cnx, divergent_blocks, chain_name, subgraph_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T22:05:23.809106Z",
+     "start_time": "2021-06-14T22:05:22.639Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "local_diverge_changes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T22:05:23.810146Z",
+     "start_time": "2021-06-14T22:05:22.641Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "local_diverge_call_cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T22:05:23.811079Z",
+     "start_time": "2021-06-14T22:05:22.643Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Save entity updates to a local csv\n",
+    "local_diverge_changes.to_csv(output_dir + subgraph_name + '_' + indexer_name + '_entity_updates_in_divergent_blocks.csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare between two indexers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-14T22:05:23.812141Z",
+     "start_time": "2021-06-14T22:05:22.645Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Example of comparing two sets of entity updates (in this case it )\n",
+    "local_diverge_changes2 = fetch_entity_updates_for_blocks(indexer_name, indexer_local_db_cnx, divergent_blocks, subgraph_id)\n",
+    "diffs = local_diverge_changes.compare(local_diverge_changes2)\n",
+    "len(diffs)"
+   ]
+  }
+ ],
+ "metadata": {
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR Initializing the analysis directory with some template Jupyter notebooks created for automating analysis of PoI divergence incidents.

The two Jupyter notebooks here are meant to be used together to automate much of the PoI divergence analysis process.  
1. Analyzes multiple PoI tables to identify points of divergence (block numbers) and identify which subgraph event triggers fired in the "divergent" blocks,
2. Fetches all entity updates and eth call cache records for a given subgraph deployment and set of blocks.

_Note: For reference on the PoI divergence analysis process see my recent forum post describing analysis for the first set of disputes._