### PR TITLE
filter disputes by status

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Run `graph-disputes` with no parameters to see a list of commands.
 graph-dispute setup
 
 # General
-graph-disputes dispute list
+graph-disputes dispute list [--status <accepted|rejected|draw|undecided|all>]
 graph-disputes dispute show <disputeID>
 
 # Submitter

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -11,6 +11,14 @@ import { getDisputes } from '../model'
 export const listCommand = {
   command: 'list',
   describe: 'List disputes',
+  builder: (yargs: Argv): Argv => {
+    return yargs.option('status', {
+      description: 'Dispute status',
+      type: 'string',
+      choices: ['accepted', 'rejected', 'draw', 'undecided', 'all'],
+      default: 'undecided',
+    })
+  },
   handler: async (
     argv: { [key: string]: any } & Argv['argv'],
   ): Promise<void> => {
@@ -20,7 +28,12 @@ export const listCommand = {
     // Get disputes to list
     const spinner = ora('Loading disputes...\n').start()
     const data = {}
-    const disputes = await getDisputes(networkSubgraph)
+    // capitalize the status
+    const status =
+      argv.status === 'all'
+        ? undefined
+        : argv.status[0].toUpperCase() + argv.status.substring(1)
+    const disputes = await getDisputes(networkSubgraph, status)
     log.info(`Found: ${disputes.length}\n`)
 
     // Process each dispute and populate additional information

--- a/src/model.ts
+++ b/src/model.ts
@@ -96,12 +96,18 @@ export const getAllocation = async (
 
 export const getDisputes = async (
   networkSubgraph: Client,
+  status: string,
 ): Promise<Dispute[]> => {
+  const where = status ? '{ status: $status }' : '{}'
   const result = await networkSubgraph
     .query(
       gql`
-        {
-          disputes(orderBy: "createdAt", orderDirection: "asc") {
+        query($status: DisputeStatus) {
+          disputes(
+            orderBy: "createdAt"
+            orderDirection: "asc"
+            where: ${where}
+          ) {
             id
             type
             status
@@ -127,6 +133,7 @@ export const getDisputes = async (
           }
         }
       `,
+      { status },
     )
     .toPromise()
   return result.data.disputes


### PR DESCRIPTION
**Summary**

Added a new flag `--status` to `graph-disputes dispute list`

By default only disputes with status `undecided` are fetched.

To fetch all disputes you can use:
```
graph-disputes dispute list --status all
```

----
I'll update the README with the usage in a following commit