### PR TITLE
Simplify cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,18 @@ Run `graph-disputes` with no parameters to see a list of commands.
 graph-dispute setup
 
 # General
-graph-disputes dispute list [--status <accepted|rejected|draw|undecided|all>]
-graph-disputes dispute show <disputeID>
+graph-disputes list [--status <accepted|rejected|draw|undecided|all>]
+graph-disputes show <disputeID>
 
 # Submitter
-graph-disputes dispute create indexing <allocationID> <deposit>
-graph-disputes dispute create query <attestation> <deposit>
+graph-disputes create indexing <allocationID> <deposit>
+graph-disputes create query <attestation> <deposit>
 
 # Arbitrator
-graph-disputes dispute resolve reject <disputeID>
-graph-disputes dispute resolve accept <disputeID>
-graph-disputes dispute resolve draw <disputeID>
-graph-disputes dispute resolve verify <payload>
+graph-disputes resolve reject <disputeID>
+graph-disputes resolve accept <disputeID>
+graph-disputes resolve draw <disputeID>
+graph-disputes resolve verify <payload>
 ```
 
 
@@ -123,7 +123,7 @@ The Arbitration process is managed by a Multisig that can be changed anytime by 
 
 ### List Disputes
 
-The `list` command allows shows you the active disputes:
+The `list` command shows you the active (undecided) disputes:
 
 ```bash
 graph-dispute list

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -13,16 +13,14 @@ export const listCommand = {
   describe: 'List disputes',
   builder: (yargs: Argv): Argv => {
     return yargs
+      .usage('$0 [--status <accepted|rejected|draw|undecided|all>]')
       .option('status', {
         description: 'Dispute status',
+        group: 'List',
         type: 'string',
         choices: ['accepted', 'rejected', 'draw', 'undecided', 'all'],
         default: 'undecided',
       })
-      .usage(
-        '$0 [--status <accepted|rejected|draw|undecided|all>]',
-        'List disputes',
-      )
   },
   handler: async (
     argv: { [key: string]: any } & Argv['argv'],

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -12,12 +12,17 @@ export const listCommand = {
   command: 'list',
   describe: 'List disputes',
   builder: (yargs: Argv): Argv => {
-    return yargs.option('status', {
-      description: 'Dispute status',
-      type: 'string',
-      choices: ['accepted', 'rejected', 'draw', 'undecided', 'all'],
-      default: 'undecided',
-    })
+    return yargs
+      .option('status', {
+        description: 'Dispute status',
+        type: 'string',
+        choices: ['accepted', 'rejected', 'draw', 'undecided', 'all'],
+        default: 'undecided',
+      })
+      .usage(
+        '$0 [--status <accepted|rejected|draw|undecided|all>]',
+        'List disputes',
+      )
   },
   handler: async (
     argv: { [key: string]: any } & Argv['argv'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { basename } from 'path'
-import yargs, { Argv } from 'yargs'
+import yargs from 'yargs'
 import fs from 'fs'
 import findUp from 'find-up'
 
@@ -29,51 +29,41 @@ yargs
   })
   .default('config', DEFAULT_CONFIG_NAME)
   .command(setupCommand)
-  .command({
-    command: 'dispute',
-    describe: 'Dispute management',
-    builder: (yargs: Argv): Argv => {
-      return yargs
-        .option('ethereum', {
-          description: 'Ethereum node or provider URL',
-          type: 'string',
-          required: true,
-          group: 'Ethereum',
-        })
-        .option('ethereum-network', {
-          description: 'Ethereum network',
-          type: 'string',
-          required: false,
-          default: 'mainnet',
-          group: 'Ethereum',
-        })
-        .option('network-subgraph-endpoint', {
-          description: 'Endpoint to query the network subgraph from',
-          type: 'string',
-          required: true,
-          group: 'Network Subgraph',
-        })
-        .option('trusted-subgraph-endpoint', {
-          description: 'Endpoint to query the trusted indexing proofs',
-          type: 'string',
-          required: true,
-          group: 'Trusted Subgraph',
-        })
-        .option('log-level', {
-          description: 'Log level',
-          type: 'string',
-          default: 'debug',
-          group: 'Logging',
-        })
-        .command(createCommand)
-        .command(listCommand)
-        .command(showCommand)
-        .command(resolveCommand)
-        .command(inspectCommand)
-        .demandCommand(1, 'Choose a command from the above list')
-    },
-    handler: async (): Promise<void> => {
-      yargs.showHelp()
-    },
+  .option('ethereum', {
+    description: 'Ethereum node or provider URL',
+    type: 'string',
+    required: true,
+    group: 'Ethereum',
   })
+  .option('ethereum-network', {
+    description: 'Ethereum network',
+    type: 'string',
+    required: false,
+    default: 'mainnet',
+    group: 'Ethereum',
+  })
+  .option('network-subgraph-endpoint', {
+    description: 'Endpoint to query the network subgraph from',
+    type: 'string',
+    required: true,
+    group: 'Network Subgraph',
+  })
+  .option('trusted-subgraph-endpoint', {
+    description: 'Endpoint to query the trusted indexing proofs',
+    type: 'string',
+    required: true,
+    group: 'Trusted Subgraph',
+  })
+  .option('log-level', {
+    description: 'Log level',
+    type: 'string',
+    default: 'debug',
+    group: 'Logging',
+  })
+  .command(createCommand)
+  .command(listCommand)
+  .command(showCommand)
+  .command(resolveCommand)
+  .command(inspectCommand)
+  .demandCommand(1, 'Choose a command from the above list')
   .help().argv


### PR DESCRIPTION
**Summary**

- Removed the command `dispute` and moved all its sub-commands to the top level.
- Also display the help command by default

Example:

```sh
❯ graph-disputes
graph-disputes <command>

Commands:
  graph-disputes setup                   Setup config
  graph-disputes create                  Create dispute
  graph-disputes list                    List disputes
  graph-disputes show <id>               Show arbitration dispute
  graph-disputes resolve                 Resolve dispute
  graph-disputes inspect <allocationID>  Inspect allocation

Ethereum
  --ethereum          Ethereum node or provider URL          [string] [required]
  --ethereum-network  Ethereum network             [string] [default: "mainnet"]

Network Subgraph
  --network-subgraph-endpoint  Endpoint to query the network subgraph from
                                                             [string] [required]

Trusted Subgraph
  --trusted-subgraph-endpoint  Endpoint to query the trusted indexing proofs
                                                             [string] [required]

Logging
  --log-level  Log level                             [string] [default: "debug"]

Options:
  --version  Show version number                                       [boolean]
  --config   Path to JSON config file               [default: ".graph-disputes"]
  --help     Show help                                                 [boolean]

Choose a command from the above list

```