### PR TITLE
Check thawing period before resolving dispute

### DIFF
--- a/src/dispute.ts
+++ b/src/dispute.ts
@@ -32,10 +32,30 @@ function styleDisputeStatus(status: string) {
   return chalk.dim(status)
 }
 
+function styleClosedAtEpoch(
+  closedAtEpoch: number,
+  networkSettings: GraphNetwork,
+) {
+  if (isDisputeOlderThanTwoThawingPeriods(closedAtEpoch, networkSettings)) {
+    return chalk.redBright(closedAtEpoch)
+  }
+  return closedAtEpoch
+}
+
 const DAY_SECONDS = 60 * 60 * 24
 
 function relativeDays(ts: number) {
   return ((+new Date() / 1000 - ts) / DAY_SECONDS).toFixed(2)
+}
+
+export const isDisputeOlderThanTwoThawingPeriods = (
+  closedAtEpoch: number,
+  networkSettings: GraphNetwork,
+): boolean => {
+  const { currentEpoch, thawingPeriod, epochLength } = networkSettings
+  const thawingPeriodInEpochs = Math.round(thawingPeriod / epochLength)
+
+  return currentEpoch - closedAtEpoch > 2 * thawingPeriodInEpochs
 }
 
 export const populateEntry = async (
@@ -106,7 +126,10 @@ export const populateEntry = async (
       id: chalk.cyanBright(dispute.allocation.id),
       createdAtEpoch: dispute.allocation.createdAtEpoch,
       createdAtBlock: dispute.allocation.createdAtBlockHash,
-      closedAtEpoch: dispute.allocation.closedAtEpoch,
+      closedAtEpoch: styleClosedAtEpoch(
+        dispute.allocation.closedAtEpoch,
+        networkSettings,
+      ),
       closedAtBlock: `${dispute.allocation.closedAtBlockHash} (#${dispute.allocation.closedAtBlockNumber})`,
     },
     POI: {

--- a/src/model.ts
+++ b/src/model.ts
@@ -53,6 +53,9 @@ export interface GraphNetwork {
   indexingSlashingPercentage: number
   minimumDisputeDeposit: number
   querySlashingPercentage: number
+  currentEpoch: number
+  thawingPeriod: number
+  epochLength: number
 }
 
 export const getEpoch = async (
@@ -178,15 +181,21 @@ export const getDispute = async (
               closedAtBlockHash
               closedAtBlockNumber
               poi
+              indexingIndexerRewards
             }
             subgraphDeployment {
               id
             }
             indexer {
               id
+              defaultDisplayName
+              indexer {
+                stakedTokens
+              }
             }
             fisherman {
               id
+              defaultDisplayName
             }
           }
         }
@@ -208,6 +217,9 @@ export const getNetworkSettings = async (
           graphNetwork(id: $networkId) {
             id
             indexingSlashingPercentage
+            currentEpoch
+            thawingPeriod
+            epochLength
           }
         }
       `,

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,10 +1,11 @@
 import { providers } from 'ethers'
 import treeify from 'treeify'
 import ora from 'ora'
+import chalk from 'chalk'
 import { DisputeManager } from '@graphprotocol/contracts/dist/types/DisputeManager'
 
 import { log } from './logging'
-import { populateEntry } from './dispute'
+import { populateEntry, isDisputeOlderThanTwoThawingPeriods } from './dispute'
 import { Environment } from './env'
 import { getDispute, getNetworkSettings } from './model'
 import { waitTransaction } from './network'
@@ -80,6 +81,23 @@ export class DisputeResolver {
     // TODO: show the bond the submitter will get
   }
 
+  async validateStatuteOfLimitations(disputeID: string): Promise<boolean> {
+    const dispute = await getDispute(this.env.networkSubgraph, disputeID)
+    const networkSettings = await getNetworkSettings(this.env.networkSubgraph)
+    return !isDisputeOlderThanTwoThawingPeriods(
+      dispute.allocation.closedAtEpoch,
+      networkSettings,
+    )
+  }
+
+  showStatuteOfLimitationsError(): void {
+    const message = chalk.redBright(`
+    This dispute cannot be accepted or rejected because its allocation closed more than 2 thawing periods ago.
+    For more information refer to the Arbitration Charter, Section 6: Statute of Limitations.
+    `)
+    log.error(message)
+  }
+
   async commit(
     disputeID: string,
     resolve: DisputeResolution,
@@ -105,13 +123,21 @@ export class DisputeResolver {
   @confirmResolve
   async accept(disputeID: string, execute = false): Promise<void> {
     log.info(`Accepting dispute ${disputeID}...`)
-    await this.commit(disputeID, DisputeResolution.Accept, execute)
+    if (await this.validateStatuteOfLimitations(disputeID)) {
+      await this.commit(disputeID, DisputeResolution.Accept, execute)
+    } else {
+      this.showStatuteOfLimitationsError()
+    }
   }
 
   @confirmResolve
   async reject(disputeID: string, execute = false): Promise<void> {
     log.info(`Rejecting dispute ${disputeID}...`)
-    await this.commit(disputeID, DisputeResolution.Reject, execute)
+    if (await this.validateStatuteOfLimitations(disputeID)) {
+      await this.commit(disputeID, DisputeResolution.Reject, execute)
+    } else {
+      this.showStatuteOfLimitationsError()
+    }
   }
 
   @confirmResolve


### PR DESCRIPTION
**Summary**
- Show the `closedAtEpoch` in red on the dispute if more than 2 thawing periods have elapsed since.
- Show an error message when trying to accept or reject a dispute as an arbitrator if more than 2 thawing periods have elapsed since the allocation closed.