### PR TITLE
fix: make trusted subgraph network optional in setup command

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -52,9 +52,10 @@ export const setupCommand = {
       },
       {
         name: 'trusted-subgraph-network',
-        message: 'Trusted Subgraph Endpoint (Leave empty to skip)',
-        validate: (value: string) =>
-          value.length > 0 ? isValidURL(value) : true,
+        message: 'Trusted Subgraph Endpoint',
+        default: (answers: inquirer.Answers) =>
+          answers['network-subgraph-endpoint'],
+        validate: isValidURL,
       },
     ])
     // Save config file

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -10,10 +10,6 @@ const isValidURL = (value: string): boolean | string => {
   return isValid || 'Invalid URL'
 }
 
-const isValidTrustedSubgraph = (value: string): boolean | string => {
-  return value.length > 0 ? isValidURL(value) : true
-}
-
 export const setupCommand = {
   command: 'setup',
   describe: 'Setup config',

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -10,6 +10,10 @@ const isValidURL = (value: string): boolean | string => {
   return isValid || 'Invalid URL'
 }
 
+const isValidTrustedSubgraph = (value: string): boolean | string => {
+  return value.length > 0 ? isValidURL(value) : true
+}
+
 export const setupCommand = {
   command: 'setup',
   describe: 'Setup config',
@@ -52,8 +56,9 @@ export const setupCommand = {
       },
       {
         name: 'trusted-subgraph-network',
-        message: 'Trusted Subgraph Endpoint',
-        validate: isValidURL,
+        message: 'Trusted Subgraph Endpoint (Leave empty to skip)',
+        validate: (value: string) =>
+          value.length > 0 ? isValidURL(value) : true,
       },
     ])
     // Save config file


### PR DESCRIPTION
Currently the setup command will require to provide a URL for the Trusted Subgraph Endpoint. If not using one (for example any indexer running the software) the only way to finish the setup is to provide any url. 

```
tomi@ceres:/U/t/g/th/graph-disputes (main) ./bin/graph-disputes setup
? Ethereum Node RPC-URL https://eth-mainnet.g.alchemy.com/v2/<CENSORED>
? Ethereum Network mainnet
? Network Subgraph Endpoint https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-mainnet
? Trusted Subgraph Endpoint ›
```

Signed-off-by: Tomás Migone <tomas@edgeandnode.com>