### PR TITLE
arbitrum-one support

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -43,6 +43,10 @@ export const setupCommand = {
             key: 'rinkeby',
             value: 'rinkeby',
           },
+	  {
+            key: 'arbitrum-one',
+            value: 'arbitrum-one',
+          }
         ],
       },
       {

--- a/src/env.ts
+++ b/src/env.ts
@@ -36,7 +36,7 @@ export const setupEnv = async (
       password: ethereum.password,
       allowInsecureAuthentication: true,
     },
-    argv.ethereumNetwork,
+    argv.ethereumNetwork == 'arbitrum-one' ? 'arbitrum' : argv.ethereumNetwork,
   )
   const network = await provider.getNetwork()
 


### PR DESCRIPTION
Allow setting "arbitrum-one" as the network. As ethers.js uses the "arbitrum" name instead, a mapping is performed. 