### PR TITLE
fix: dont specify network name when initializing RPC

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -29,15 +29,12 @@ export const setupEnv = async (
     throw err
   }
 
-  const provider = new providers.StaticJsonRpcProvider(
-    {
-      url: ethereum.toString(),
-      user: ethereum.username,
-      password: ethereum.password,
-      allowInsecureAuthentication: true,
-    },
-    argv.ethereumNetwork,
-  )
+  const provider = new providers.StaticJsonRpcProvider({
+    url: ethereum.toString(),
+    user: ethereum.username,
+    password: ethereum.password,
+    allowInsecureAuthentication: true,
+  })
   const network = await provider.getNetwork()
 
   // Contracts


### PR DESCRIPTION
There is no need to do it nowadays and it's making the tool fail.